### PR TITLE
make logdna DRY again

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Tunables
 --------
 * `logdna_logging_directory` (string) - The directory logdna should monitor for logs.
+* `logdna_logging_files` (string) - The comma-sepreated files logdna should monitor for logs.
 * `logdna_secret_key` (string) - The key associated with your logdna account.
 
 Dependencies

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -8,18 +8,3 @@
     force: yes
     name: logdna-agent
     update_cache: yes
-
-- name: Configure | logdna secret key
-  become: true
-  shell: "logdna-agent -k {{ logdna_secret_key }}"
-
-- name: Configure | directory log location
-  become: true
-  shell: "logdna-agent -d {{ logdna_logging_directory }}"
-
-- name: Configure | service | logdna-agent
-  become: true
-  service:
-    name: logdna-agent
-    enabled: yes
-  notify: service | logdna-agent | started

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -11,18 +11,3 @@
   yum:
     state: latest
     name: logdna-agent
-
-- name: Configure | logdna secret key
-  become: true
-  shell: "logdna-agent -k {{ logdna_secret_key }}"
-
-- name: Configure | directory log location
-  become: true
-  shell: "logdna-agent -d {{ logdna_logging_directory }}"
-
-- name: Configure | service | logdna-agent
-  become: true
-  service:
-    name: logdna-agent
-    enabled: yes
-  notify: service | logdna-agent | started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,24 @@
 
 - include: install-debian.yml
   when: ansible_os_family == 'Debian'
+
+- name: Configure | logdna secret key
+  become: true
+  shell: "logdna-agent -k {{ logdna_secret_key }}"
+
+- name: Configure | directory log location
+  become: true
+  shell: "logdna-agent -d {{ logdna_logging_directory }}"
+  when: logdna_logging_directory is defined
+
+- name: Configure | file log locations
+  become: true
+  shell: "logdna-agent -d {{ logdna_logging_files }}"
+  when: logdna_logging_files is defined
+
+- name: Configure | service | logdna-agent
+  become: true
+  service:
+    name: logdna-agent
+    enabled: yes
+  notify: service | logdna-agent | started


### PR DESCRIPTION
the configure steps are the same for debiand and redhat so they
shouldn't exist twice

also add variable to specify files